### PR TITLE
--bug=1026300 --user=何定良 【验收缺陷】【基础组】公司组-新建数据后页面跳转报错 https://www.tapd.…

### DIFF
--- a/src/components/basic/edit-table/index.js
+++ b/src/components/basic/edit-table/index.js
@@ -348,7 +348,8 @@ class EditTable extends Component {
       options.initialValue = record[latestAttr.valueMapKey]
         ? {
             value: record[latestAttr.valueMapKey],
-            label: record[latestAttr.valueMapLabel],
+            // selectPartLoad 的值是 {label, value}, 必须要拆解出 label, 否则会无限套娃直接报错
+            label: record[latestAttr.valueMapLabel]?.label ?? record[latestAttr.valueMapLabel],
           }
         : undefined;
     } else if (latestAttr.valueMap) {


### PR DESCRIPTION
…cn/34592457/s/2109976

selectPartLoad 的值是 {label, value}, 必须要拆解出 label, 否则会无限套娃直接报错