### PR TITLE
fix: CustomTable column render-fn 兼容原来的支持返回 {children, props} 对象 - 【【…

### DIFF
--- a/src/components/basic/custom-table/index.js
+++ b/src/components/basic/custom-table/index.js
@@ -676,7 +676,7 @@ class CustomTable extends Component {
           const tempRender = item.render;
           item.render = (values, record, index) => {
             const renderRs = tempRender(values, record, index);
-            if (renderRs.children && renderRs.props) {
+            if (renderRs && renderRs.children && renderRs.props) {
               return renderRs;
             } else {
               return <div className="over-range">{renderRs}</div>;

--- a/src/components/basic/custom-table/index.js
+++ b/src/components/basic/custom-table/index.js
@@ -674,11 +674,14 @@ class CustomTable extends Component {
         if (item.fixed) item.ellipsis = true;
         if (item.render) {
           const tempRender = item.render;
-          item.render = (values, record, index) => (
-            <div className="over-range">
-              {tempRender(values, record, index)}
-            </div>
-          );
+          item.render = (values, record, index) => {
+            const renderRs = tempRender(values, record, index);
+            if (renderRs.children && renderRs.props) {
+              return renderRs;
+            } else {
+              return <div className="over-range">{renderRs}</div>;
+            }
+          };
         } else {
           item.render = (values) => <div className="over-range">{values}</div>;
         }


### PR DESCRIPTION
…智能审核BUG】——【智能审核结果查询】报错】https://www.tapd.cn/34592457/bugtrace/bugs/view?bug_id=1134592457001026880