### PR TITLE
fix: EditTable组件列字段超出列宽重叠 - 【前端框架组件优化 - EditTable组件如果列没有设置编辑类型，其值超出列宽…

### DIFF
--- a/src/components/basic/edit-table/index.js
+++ b/src/components/basic/edit-table/index.js
@@ -222,12 +222,22 @@ class EditTable extends Component {
           // 开放 renderNormalCell方法，renderEditCell方法，分别渲染文本状态及 编辑状态下,用于兼容外界自定义复杂逻辑的表单时
           let result;
           if (column.render) {
-            result = column.render(
+            const tempRender = column.render;
+            const newRender = (...rest) => (
+              <div className="over-range">{tempRender(...rest)}</div>
+            );
+            result = newRender(
               value,
               record,
               index,
               addKeys.indexOf(record[rowKey]) >= 0,
             );
+            // result = column.render(
+            //   value,
+            //   record,
+            //   index,
+            //   addKeys.indexOf(record[rowKey]) >= 0,
+            // );
           } else if (column.renderNormalCell && column.renderEditCell) {
             result = undefined;
           } else


### PR DESCRIPTION
…没有省略】https://www.tapd.cn/34592457/prong/tasks/view/1134592457001073764