### PR TITLE
EditTable 操作列去掉 padding-right: 65px; 并优化点击操作 【【费控条线优化】可编辑列表最后一列信息显示不全…

### DIFF
--- a/src/components/basic/edit-table/index.less
+++ b/src/components/basic/edit-table/index.less
@@ -37,16 +37,6 @@
         border-radius: 0;
       }
     }
-    .ant-table-thead > tr {
-      .ant-table-cell:nth-last-of-type(2) {
-        padding-right: 65px;
-      }
-    }
-    .ant-table-row {
-      .ant-table-cell:nth-last-of-type(2) {
-        padding-right: 65px;
-      }
-    }
 
     .ant-table-cell {
       .ant-legacy-form-item-control {
@@ -90,6 +80,7 @@
       .operation-group-box {
         position: relative;
         .cell-outer-box {
+          pointer-events: none;
           width: 44px;
           height: 100%;
           position: absolute;
@@ -112,6 +103,13 @@
             color: #1790ff;
             & + span {
               margin-left: 24px;
+            }
+          }
+          .anticon {
+            pointer-events: all;
+            opacity: 0.3;
+            &:hover {
+              opacity: 1;
             }
           }
         }


### PR DESCRIPTION
…/对齐方式优化】https://www.tapd.cn/34592457/bugtrace/bugs/view?bug_id=1134592457001026967